### PR TITLE
Correct dot-key claims

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -16,7 +16,7 @@ console.log(get(obj, 'a.b.c.d')); //=> 'foo'
 
 ### Supports keys with dots
 
-Unlike other dot-prop libraries, get-value works when keys have dots in them:
+Unlike many other dot-prop libraries, get-value works when keys have dots in them:
 
 ```js
 console.log(get({ 'a.b': { c: 'd' } }, 'a.b.c'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-value",
-  "description": "Use property paths like 'a.b.c' to get a nested value from an object. Even works when keys have dots in them (no other dot-prop library can do this!).",
+  "description": "Use property paths like 'a.b.c' to get a nested value from an object. Even works when keys have dots in them.",
   "version": "3.0.1",
   "homepage": "https://github.com/jonschlinkert/get-value",
   "author": "Jon Schlinkert (https://github.com/jonschlinkert)",


### PR DESCRIPTION
[dotty](https://www.npmjs.com/dotty) also supports dot-key access (through the array notation).

Did not re-generate README.md, as the necessary dependencies / scripts don't seem to be declared in the package.json.