### PR TITLE
fix: dist/index.mjs missing in 4.0.0 #30 and missing index.d.ts #28

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,47 @@
+export = get;
+
+declare function get<T>(obj: T): T;
+declare function get(obj: object, key: string | string[], options?: get.Options): any;
+
+declare namespace get {
+  interface Options {
+    /**
+     * The default value to return when get-value cannot result a value from the given object.
+     *
+     * default: `undefined`
+     */
+    default?: any;
+    /**
+     * If defined, this function is called on each resolved value.
+     * Useful if you want to do `.hasOwnProperty` or `Object.prototype.propertyIsEnumerable`.
+     */
+    isValid?: (<K extends string>(key: K, object: Record<K, any>) => boolean) | undefined;
+    /**
+     * Custom function to use for splitting the string into object path segments.
+     *
+     * default: `String.split`
+     */
+    split?: ((s: string) => string[]) | undefined;
+    /**
+     * The separator to use for spliting the string.
+     * (this is probably not needed when `options.split` is used).
+     *
+     *  default: `"."`
+     */
+    separator?: string | RegExp | undefined;
+    /**
+     * Customize how the object path is created when iterating over path segments.
+     *
+     * default: `Array.join`
+     */
+    join?: ((segs: string[]) => string) | undefined;
+    /**
+     * The character to use when re-joining the string to check for keys
+     * with dots in them (this is probably not needed when `options.join` is used).
+     * This can be a different value than the separator, since the separator can be a string or regex.
+     *
+     * default: `"."`
+     */
+    joinChar?: string | undefined;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,12 +17,16 @@
     "tsup": "npx tsup"
   },
   "files": [
-    "dist/index.js"
+    "dist/index.js",
+    "dist/index.mjs",
+    "index.d.ts"
   ],
   "main": "dist/index.js",
   "module": "dist/index.mjs",
+  "types": "index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     }


### PR DESCRIPTION
This PR is intended to quickly fix these two issues: 
- https://github.com/jonschlinkert/get-value/issues/28
- https://github.com/jonschlinkert/get-value/issues/30

Among them, the dts file is obtained from [@types/get-value](https://www.npmjs.com/package/@types/get-value) and then submitted here. 

This can be improved by enhancing the types in the `index.ts` file and enabling dts in the `tsup.config.ts`.

Perhaps I can improve these types and submit them for your review.

