### PR TITLE
fix: point package types at dist where the build emits them

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,18 @@
   ],
   "main": "dist/index.js",
   "module": "dist/index.mjs",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "exports": {
     "./package": "./package.json",
     ".": {
-      "types": "./index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     }
   },
   "devDependencies": {


### PR DESCRIPTION
The build emits type declarations to `dist/index.d.ts` and `dist/index.d.mts`, but `package.json` still pointed the top-level `types` field and the `"."` export's `types` condition at the root `./index.d.ts`. Only `dist` is published (`files: ["dist"]`), so that path isn't in the tarball and TypeScript resolves no declarations — consumers of `get-value` get no types.

This points the declarations at where the build actually emits them:

- top-level `types` → `dist/index.d.ts`
- the `"."` export split into `import`/`require` conditions, each with its `types` pointing at the matching file (`dist/index.d.mts` for ESM, `dist/index.d.ts` for CJS)

The mismatch was introduced when the build output moved into `dist/` (#31) without updating the type pointers.

Closes #37
